### PR TITLE
Change C++ runner to use clang++ alias

### DIFF
--- a/tool/runners/cpp.py
+++ b/tool/runners/cpp.py
@@ -13,11 +13,10 @@ class SubmissionCpp(SubmissionWrapper):
         tmp.close()
         compile_output = subprocess.check_output(
             [
-                "clang-16",
+                "clang++",
                 "-Wall",
                 "-Wextra",
                 "-O3",
-                "-lstdc++",
                 "-lm",
                 "-std=c++20",
                 "-o",


### PR DESCRIPTION
This makes the runner more robust on dev machines as it doesn't rely on any specific version being installed and aliased.

Also switch to clang++ since it implicitly links C++ runtime libs.